### PR TITLE
[docs] add module declaration to config hashx

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The following connection configuration is available:
 ```javascript
 // default values inline
 config: {
+  module: 'sails-redis', 
   port: 6379,
   host: 'localhost',
   password: null,


### PR DESCRIPTION
not sure if this makes sense if adapter name is changing to `waterline-redis`, but was confusing to me as I was getting started.
