### PR TITLE
Added support for simple KV pair operations, including expiring keys.

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -135,6 +135,49 @@ module.exports = (function () {
   native: function(collectionName, cb) {
     var connection = database.schema._connections[collectionName];
     return cb(null, connection);
+  },
+
+  /**
+   * Simple KV pair setter with an expiration time.
+   * @param collectionName
+   * @param key
+   * @param data
+   * @param seconds Set to null for non-expiring values.
+   * @param cb
+   */
+  setWithTTL: function (collectionName, key, data, seconds, cb) {
+    database.setWithTTL(collectionName, key, data, seconds, cb);
+  },
+
+  /**
+   * A cleaner 'set' API for the non-expiring case.
+   * @param collectionName
+   * @param key
+   * @param data
+   * @param cb
+   */
+  set: function (collectionName, key, data, cb) {
+    database.setWithTTL(collectionName, key, data, null, cb);
+  },
+
+  /**
+   * Set (or update) the remaining TTL on a KV pair.
+   * @param collectionName
+   * @param key
+   * @param seconds
+   * @param cb
+   */
+  setTTL: function(collectionName, key, seconds, cb) {
+    database.setTTL(collectionName, key, seconds, cb);
+  },
+
+  get: function (collectionName, key, cb) {
+    database.get(collectionName, key, cb);
+  },
+
+  remove: function (collectionName, key, cb) {
+    database.remove(collectionName, key, cb);
   }
+
 };
 })();

--- a/lib/database/index.js
+++ b/lib/database/index.js
@@ -679,6 +679,122 @@ Database.prototype.destroy = function destroy(collectionName, criteria, cb) {
   });
 };
 
+
+///////////////////////////////////////////////////////////////////////////////////////////
+/// Raw KV pair operations. No Waterline hooks (beforeCreate, etc.) will be called.
+///////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Get the value of a simple KV pair
+ *
+ * @param {String} collectionName
+ * @param {Object} key
+ * @param {Function} callback
+ * @api public
+ */
+Database.prototype.get = function get(collectionName, key, next) {
+    var connection = this.schema._connections[collectionName];
+    var noSqlKey = Utils.sanitize(key);
+    var name = collectionName.toLowerCase();
+    var self = this;
+
+    // Find the newly created record and return it
+    connection.get(noSqlKey, function processResult (err, retrievedValue) {
+        if(err) return next(err);
+
+        // Parse JSON into an object
+        try {
+            retrievedValue = JSON.parse(retrievedValue);
+        } catch(e) {
+            return next(e);
+        }
+
+        next(null, self.schema.parse(name, retrievedValue));
+    });
+};
+
+/**
+ * Set a simple KV pair. No indeces, auto increment fields or other
+ * such things will be stored.
+ *
+ * @param {String} collectionName
+ * @param {Object} key
+ * @param {Object} value
+ * @param {int} seconds (null for no expiration)
+ * @param {Function} callback
+ * @api public
+ */
+Database.prototype.setWithTTL = function setWithTTL(collectionName, key, value, seconds, next) {
+    var connection = this.schema._connections[collectionName];
+    var noSqlKey = Utils.sanitize(key);
+    var name = collectionName.toLowerCase();
+    var self = this;
+
+    // Stringify data for storage
+    var parsedData;
+    try {
+        parsedData = JSON.stringify(value);
+    } catch(e) {
+        return next(e);
+    }
+
+    function sendResults(err, results) {
+        if(err) return next(err);
+
+        // Find the newly created record and return it
+        connection.get(noSqlKey, function(err, retrievedValue) {
+            if(err) return next(err);
+
+            // Parse JSON into an object
+            try {
+                retrievedValue = JSON.parse(retrievedValue);
+            } catch(e) {
+                return next(e);
+            }
+
+            return next(null, self.schema.parse(name, retrievedValue));
+        });
+    }
+
+    if (seconds) {
+        connection.setex(noSqlKey, seconds, parsedData, sendResults);
+    } else {
+        connection.set(noSqlKey, parsedData, sendResults);
+    }
+};
+
+/**
+ * Set (or update) the TTL on a simple KV pair.
+ *
+ * @param {String} collectionName
+ * @param {Object} key
+ * @param {integer} seconds Time in seconds until expiration.
+ * @param {Function} callback
+ * @api public
+ */
+Database.prototype.setTTL = function setTTL(collectionName, key, seconds, next) {
+    var connection = this.schema._connections[collectionName];
+    var noSqlKey = Utils.sanitize(key);
+
+    connection.expire(noSqlKey, seconds, next);
+};
+
+/**
+ * Remove a simple KV pair
+ *
+ * @param {String} collectionName
+ * @param {Object} key
+ * @param {Function} callback
+ * @api public
+ */
+Database.prototype.remove = function get(collectionName, key, next) {
+    var connection = this.schema._connections[collectionName];
+    var noSqlKey = Utils.sanitize(key);
+
+    // Remove key
+    connection.del(noSqlKey, next);
+};
+
 ///////////////////////////////////////////////////////////////////////////////////////////
 /// CONSTRAINTS
 ///////////////////////////////////////////////////////////////////////////////////////////

--- a/test/unit/adapter.kvpair.js
+++ b/test/unit/adapter.kvpair.js
@@ -1,0 +1,127 @@
+/**
+ * Test dependencies
+ */
+
+var assert = require('assert'),
+    Adapter = require('../../'),
+    Support = require('../support')(Adapter),
+    Errors = require('waterline-errors').adapter;
+
+/**
+ * Raw waterline-redis key-value pair tests
+ */
+
+describe('adapter kv-pair support ', function() {
+
+    describe('kv pair set/get/remove', function() {
+        before(function(done) {
+            var definition = {
+                foo: {
+                    type: 'int'
+                },
+                bar: {
+                    type: 'string'
+                }
+            };
+
+            Support.Setup('foobar', definition, done);
+        });
+
+        after(function(done) {
+            Support.Teardown('foobar', done);
+        });
+
+        it('should set a KV pair', function(done) {
+            var attributes = {
+                foo: 1,
+                bar: 'Darth Maul'
+            };
+
+            Adapter.set('foobar', 'maulKey', attributes, function(err, model) {
+                if(err) throw err;
+                assert(model.foo === 1);
+                assert(model.bar === 'Darth Maul');
+                done();
+            });
+        });
+
+        it('should retrieve KV pair', function(done) {
+            Adapter.get('foobar', 'maulKey', function(err, model) {
+                if(err) throw err;
+                assert(model.foo === 1);
+                assert(model.bar === 'Darth Maul');
+                done();
+            });
+        });
+
+        it('should remove KV pair', function(done) {
+            Adapter.remove('foobar', 'maulKey', function(err, result) {
+                if(err) throw err;
+                assert(result === 1);
+                done();
+            });
+        });
+
+        it('should not find KV pair', function(done) {
+            Adapter.get('foobar', 'maulKey', function(err, model) {
+                if(err) throw err;
+                assert(model === null);
+                done();
+            });
+        });
+    });
+
+    describe('kv pair with expire', function() {
+        before(function(done) {
+            var definition = {
+                guitar: {
+                    type: 'string'
+                },
+                vocal: {
+                    type: 'string'
+                }
+            };
+
+            Support.Setup('classicbands', definition, done);
+        });
+
+        after(function(done) {
+            Support.Teardown('classicbands', done);
+        });
+
+        it('should set an expiring KV pair', function(done) {
+            var attributes = {
+                guitar: 'Jimmy Page',
+                vocal: 'Robert Plant'
+            };
+
+            Adapter.setWithTTL('classicbands', 'ledZepKey', attributes, 1, function(err, model) {
+                if(err) throw err;
+                assert(model.guitar === 'Jimmy Page');
+                assert(model.vocal === 'Robert Plant');
+                done();
+            });
+        });
+
+        it('should retrieve KV pair', function(done) {
+            Adapter.get('classicbands', 'ledZepKey', function(err, model) {
+                if(err) throw err;
+                assert(model.guitar === 'Jimmy Page');
+                assert(model.vocal === 'Robert Plant');
+
+                setTimeout(function(){
+                    done();
+                }, 1500);
+            });
+        });
+
+        it('should not find KV pair', function(done) {
+            Adapter.get('classicbands', 'ledZepKey', function(err, model) {
+                if(err) throw err;
+                assert(model === null);
+                done();
+            });
+        });
+    });
+
+});


### PR DESCRIPTION
Change made off of 0.9.x branch.  
- New kv-pair operations: setWithTTL(), set(), setTTL(), get(), remove()
