### PR TITLE
Create the client before trying to authenticate it

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -50,9 +50,13 @@ Connection.prototype.connect = function(cb) {
       multi,
       config = this.config;
 
-  client = config.password !== null ?
-    redis.createClient(config.port, config.host, config.options).auth(config.password) :
-    redis.createClient(config.port, config.host, config.options);
+  if (config.password !== null) {
+    client = redis.createClient(config.port, config.host, config.options);
+    client.auth(config.password);
+  }
+  else {
+    client = redis.createClient(config.port, config.host, config.options);
+  }
 
   client.once('ready', function() {
     cb(null, client);


### PR DESCRIPTION
Since the `client.auth` is an asynchronous operation, we need to create the client before trying to auth, otherwise the client might be undefined when trying to call `client.once`
