### PR TITLE
Redis error

### DIFF
--- a/lib/database/connection.js
+++ b/lib/database/connection.js
@@ -42,7 +42,11 @@ Connection.prototype.connect = function(cb) {
     redis.createClient(config.port, config.host, config.options);
 
   if (config.options.onError) {
-    client.on('error', config.options.onError);
+    client.on('error', function connectionErrorListener(){
+      var args = Array.prototype.slice.call(arguments);
+      args.push(client);
+      config.options.onError.apply(this, args);
+    });
   }
 
   var event = 'ready';


### PR DESCRIPTION
I was unable to attach an onError handler to the raw redis connection, so when we lost connectivity to redis,  the node app would just kick up a fuss, I wanted to be able to deal with that how I wanted. While I was at it, I added the possibility of listening for onReady so that you can also have your own logic for when the connection is ready.

I also made it so that when on error gets called, we pass back the raw connection so that you can say, listen for ready again and know that you've reconnected.
