### PR TITLE
Small fix to avoid null data if it's object was expired in db.

### DIFF
--- a/lib/database/index.js
+++ b/lib/database/index.js
@@ -249,6 +249,10 @@ Database.prototype.find = function find(collectionName, criteria, cb) {
         self.connection.get(member, function(err, result) {
           if(err) return done(err);
 
+          if(!result) {
+              return done();
+          }
+
           try {
             result = JSON.parse(result);
           } catch (e) {


### PR DESCRIPTION
Fix for  "Cannot set property '.(ørigindex)' of null" error. when performing a `find` query. Refer to issue #26
