### PR TITLE
upgrading node_redis to 0.12.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "lodash": "~2.4.1",
-    "redis": "~0.10.2",
+    "redis": "~0.12.1",
     "async": "~0.9.0",
     "waterline-errors": "~0.10.0",
     "waterline-criteria": "~0.10.7",


### PR DESCRIPTION
upgrades node_redis to 0.12.x, primarily so that the redis client has socket_keepalive = true by default. Prior to node_redis 0.11.x, it was not even possible to set this option. I went ahead and upgraded to 0.12.x since there are quite a few bug fixes. 

Without this change to node_redis, if you have a redis connection open but it is idle for a while, you eventually will get E_TIMEDOUT errors from the node_redis client.

The node_redis changelog is [here](https://github.com/mranney/node_redis/blob/de6692774fa563f6fbdd8b6d68d627c5f919bc39/changelog.md), but here is a synopsis of the changes and links to the corresponding pull requests where the discussions took place related to each change.

I don't see anything in here that is particularly breaking for the sails-redis use case. I ran all the tests before and after the upgrade, and got the same results. There was one test failing for me prior to this change, I filed a ticket about that with the relevant details here: https://github.com/balderdashy/sails-redis/issues/40
## node_redis changes from 0.10.x -> 0.12.1
### Fix IPv6/IPv4 family selection in node 0.11+

https://github.com/mranney/node_redis/pull/644
**Bug Fix**: fixing issue related to ipv6
### Fix unix socket support

https://github.com/mranney/node_redis/pull/642
**Bug Fix**: unix socket support bug introduced in 0.11.x was fixed.
### Improve createClient argument handling

https://github.com/mranney/node_redis/pull/642
**Bug Fix**: fixing problems introduced in 0.11.x with createClient options handling.
### IPv6 Support.

https://github.com/mranney/node_redis/pull/612
**Feature**: initial ipv6 support
### Revert error emitting and go back to throwing errors.

https://github.com/mranney/node_redis/pull/593
reverts https://github.com/mranney/node_redis/issues/522
**Bug fix**: Errors thrown in callbacks passed to node-redis should now properly bubble up past the node-redis on('error') handler, if one is defined.
### Set socket_keepalive to prevent long-lived client timeouts.

https://github.com/mranney/node_redis/pull/570
**Feature**: This allows for the `socket_keepalive` option to be passed into the client constructor to have the redis client use keepalive to prevent E_TIMEDOUT exceptions from occurring. Contrary to what the PR states, this is actually the default in node_redis 0.12.x, so no explicit socket_keepalive setting needs to be specified to get this improvement.
### Correctly reset retry timer.

https://github.com/mranney/node_redis/pull/596
**Bug fix**: correctly resets the retry timer when client.end is called, which allows the connection to immediately reconnect without waiting on a retry timer, if necessary.
### Domains protection from bad user exit.

https://github.com/mranney/node_redis/pull/575
**Feature**: protect from some weird domain's edge case
### Fix reconnection socket logic to prevent misqueued entries.

https://github.com/mranney/node_redis/pull/622
**Bug fix**: prevent buffered commands from being sent on reconnect
