### PR TITLE
Fixing error when connecting to Redis with a password

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -50,9 +50,11 @@ Connection.prototype.connect = function(cb) {
       multi,
       config = this.config;
 
-  client = config.password !== null ?
-    redis.createClient(config.port, config.host, config.options).auth(config.password) :
-    redis.createClient(config.port, config.host, config.options);
+  client = redis.createClient(config.port, config.host, config.options);
+
+  if (config.password !== null) {
+    client.auth(config.password);
+  }
 
   client.once('ready', function() {
     cb(null, client);


### PR DESCRIPTION
Fixes balderdashy/sails-redis/issues/42

Due to `client.auth()` not returning a client instance, the call to `client.once()` was blowing up.  This PR fixes that.

PS: The tests still fail due to balderdashy/sails-redis/issues/40 .  Cardinal sin to submit a PR with broken tests I know.  But it's for the safety of humanity ;)
