### PR TITLE
Add prefix config option which enables more than one server (or instance...

### DIFF
--- a/lib/database/index.js
+++ b/lib/database/index.js
@@ -22,12 +22,16 @@ var Database = module.exports = function(connection) {
   // Hold the connection
   connection = connection || { connection: {} };
 
+  if(connection.connection.options.prefix)
+    this.prefix = connection.connection.options.prefix + ':';
+  else
+    this.prefix = 'waterline:';
   this.connection = connection.connection;
 
   this.definedCollections = {};
 
   // Hold Schema for the database
-  this.schema = new Schema(connection);
+  this.schema = new Schema(connection, this.prefix);
 
   return this;
 };

--- a/lib/database/indice.js
+++ b/lib/database/indice.js
@@ -12,7 +12,7 @@ var Errors = require('waterline-errors'),
  * values that can be checked against to determine if a value is unique or not.
  */
 
-var Indice = module.exports = function(collectionName, name, client) {
+var Indice = module.exports = function(collectionName, name, prefix, client) {
 
   // Escape the collection name
   var collection = collectionName.toLowerCase();
@@ -24,7 +24,7 @@ var Indice = module.exports = function(collectionName, name, client) {
   this.name = Utils.sanitize(name);
 
   // Build a NoSQL Key name for this sequence
-  this.keyName = 'waterline:' + collectionName.toLowerCase() + ':_indicies:' + this.name;
+  this.keyName = prefix + collectionName.toLowerCase() + ':_indicies:' + this.name;
 
   return this;
 };

--- a/lib/database/schema.js
+++ b/lib/database/schema.js
@@ -16,7 +16,7 @@ var _ = require('lodash'),
  * Keeps track of the "schema".
  */
 
-var Schema = module.exports = function(connection) {
+var Schema = module.exports = function(connection, prefix) {
 
   // Hold the schema for each collection
   this._schema = {};
@@ -32,6 +32,7 @@ var Schema = module.exports = function(connection) {
 
   // Save the connection
   this._connection = connection;
+  this.prefix = prefix;
 
   return this;
 
@@ -68,13 +69,13 @@ Schema.prototype.registerCollection = function(collectionName, schema) {
 
     // Create an index for the attribute
     if(hasOwnProperty(schema[attr], 'unique')) {
-      var indice = new Indice(name, attr, this._connection);
+      var indice = new Indice(name, attr, this.prefix, this._connection);
       this._indices[name].push(indice);
     }
 
     // Create a sequence for the attribute
     if(Utils.object.hasOwnProperty(schema[attr], 'autoIncrement')) {
-      var sequence = new Sequence(name, attr, this._connection);
+      var sequence = new Sequence(name, attr, this.prefix, this._connection);
       this._sequences[name].push(sequence);
     }
   }
@@ -129,7 +130,7 @@ Schema.prototype.retrieve = function(collectionName) {
 
 Schema.prototype.indexKey = function(collectionName, index) {
   var name = collectionName.toLowerCase();
-  return 'waterline:' + name + ':' + index;
+  return this.prefix + name + ':' + index;
 };
 
 /**
@@ -143,7 +144,7 @@ Schema.prototype.indexKey = function(collectionName, index) {
 
 Schema.prototype.recordKey = function(collectionName, index, key) {
   var name = collectionName.toLowerCase();
-  return 'waterline:' + name + ':' + index + ':' + key;
+  return this.prefix + name + ':' + index + ':' + key;
 };
 
 /**

--- a/lib/database/sequence.js
+++ b/lib/database/sequence.js
@@ -11,7 +11,7 @@ var Utils = require('../utils');
  * tracking the last value available and can be incremented only.
  */
 
-var Sequence = module.exports = function(collectionName, name, client) {
+var Sequence = module.exports = function(collectionName, name, prefix, client) {
 
   // Escape the collection name
   var collection = collectionName.toLowerCase();
@@ -23,7 +23,7 @@ var Sequence = module.exports = function(collectionName, name, client) {
   this.name = Utils.sanitize(name);
 
   // Build a NoSQL Key name for this sequence
-  this.keyName = 'waterline:' + collectionName.toLowerCase() + ':_sequences:' + this.name;
+  this.keyName = prefix + collectionName.toLowerCase() + ':_sequences:' + this.name;
 
   return this;
 };


### PR DESCRIPTION
...) to use a single redis database.  prefix defaults to "waterline" the previous hard coded value
but can be set to any string in options.  E.g.
 adapter   : 'sails-redis',
  options: {
    parser: 'hiredis',
    prefix: 'waterline1',   // instance prefix to avoid collisions, default value is 'waterline'
// ... rest of options
  }
