### PR TITLE
find() with no results is not an error

### DIFF
--- a/lib/database/index.js
+++ b/lib/database/index.js
@@ -186,7 +186,7 @@ Database.prototype.find = function find(collectionName, criteria, cb) {
 
     this.connection.get(recordKey, function(err, record) {
       if(err) return cb(err);
-      if(!record) return cb(Errors.adapter.notFound);
+      if(!record) return cb(null, []);
 
       try {
         record = JSON.parse(record);

--- a/test/unit/adapter.find.js
+++ b/test/unit/adapter.find.js
@@ -234,4 +234,16 @@ describe('adapter `.find()`', function() {
     });
   });
 
+  describe("when passed an id of a record that does not exist", function () {
+
+    it("returns an empty array", function (done) {
+      var criteria = { where: { id: 9000001 } };
+      Adapter.find('finders', 'finders', criteria, function (err, records) {
+        assert(!err);
+        assert(Array.isArray(records));
+        assert(records.length === 0);
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
when you do a .find() and no record is found, it should give back an empty array instead of an error
