### PR TITLE
Fixed populate of empty associations. This avoids to execute a smembers

### DIFF
--- a/lib/database/index.js
+++ b/lib/database/index.js
@@ -181,22 +181,25 @@ Database.prototype.find = function find(collectionName, criteria, cb) {
 
   // If the primary key is contained in the criteria, a NoSQL key can be
   // constructed and we can simply grab the values. This would be a findOne.
-  if(criteria.where && Utils.present(criteria.where[primary])) {
-    recordKey = this.schema.recordKey(name, primary, criteria.where[primary]);
+  if(criteria.where && criteria.where.hasOwnProperty(primary)) {
+    if (Utils.present(criteria.where[primary])){
+      recordKey = this.schema.recordKey(name, primary, criteria.where[primary]);
 
-    this.connection.get(recordKey, function(err, record) {
-      if(err) return cb(err);
-      if(!record) return cb(null, []);
+      this.connection.get(recordKey, function(err, record) {
+        if(err) return cb(err);
+        if(!record) return cb(null, []);
 
-      try {
-        record = JSON.parse(record);
-      } catch (e) {
-        return cb(e);
-      }
+        try {
+          record = JSON.parse(record);
+        } catch (e) {
+          return cb(e);
+        }
 
-      cb(null, [self.schema.parse(name, record)]);
-    });
-
+        cb(null, [self.schema.parse(name, record)]);
+      });
+    } else {
+      return cb(null, []);
+    }
     return;
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-redis",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Redis adapter for waterline",
   "main": "index.js",
   "author": "vanetix <matmcfarland@gmail.com>",


### PR DESCRIPTION
This avoids to execute a smembers command in redis