### PR TITLE
fix for updating with unique key, fix for finding by multiple ids

### DIFF
--- a/lib/database/index.js
+++ b/lib/database/index.js
@@ -180,9 +180,9 @@ Database.prototype.find = function find(collectionName, criteria, cb) {
   // Find the index key used to keep track of all the keys in this collections
   var indexKey = this.schema.indexKey(name, primary);
 
-  // If the primary key is contained in the criteria, a NoSQL key can be
+  // If the primary key is contained in the criteria (and it is not an object/array), a NoSQL key can be
   // constructed and we can simply grab the values. This would be a findOne.
-  if(criteria.where && Utils.present(criteria.where[primary])) {
+  if(criteria.where && Utils.present(criteria.where[primary]) && typeof criteria.where[primary]!='object') {
     recordKey = this.schema.recordKey(name, primary, criteria.where[primary]);
 
     this.connection.get(recordKey, function(err, record) {

--- a/lib/database/index.js
+++ b/lib/database/index.js
@@ -51,7 +51,6 @@ var Database = module.exports = function(connection) {
 Database.prototype.configure = function configure(collectionName, schema) {
   var name = collectionName.toLowerCase();
   this.schema.registerCollection(name, schema);
-	this.alreadyIndexed=[];
 };
 
 
@@ -335,7 +334,8 @@ Database.prototype.create = function create(collectionName, data, cb) {
       name = collectionName.toLowerCase(),
       sequences = self.schema._sequences[name],
       primary = self.schema._primary[name];
-
+  var alreadyIndexed=[];
+  
   async.auto({
 	
     // Check Unique constraints
@@ -352,7 +352,7 @@ Database.prototype.create = function create(collectionName, data, cb) {
       self._uniqueConstraint(name, data, function(err) {
         if(err) return next(err);
         next();
-      });
+      },alreadyIndexed);
     },
 
     // Check that the primary key exists or is auto-incrementing
@@ -516,7 +516,8 @@ Database.prototype.update = function update(collectionName, criteria, values, cb
       name = collectionName.toLowerCase(),
 			sequences = self.schema._sequences[name]
       primary = self.schema._primary[name];
-
+	var alreadyIndexed=[];
+	
   // Don't allow the updating of primary keys
   if(Utils.present(values[primary]) && values[primary] !== criteria.where[primary]) {
     return cb(Errors.adapter.PrimaryKeyUpdate);
@@ -568,7 +569,7 @@ Database.prototype.update = function update(collectionName, criteria, values, cb
       self._uniqueConstraint(name, values, function(err) {
         if(err) return next(err);
         next();
-      });
+      },alreadyIndexed);
     }],
 
     // Check that any sequences are not being updated
@@ -617,7 +618,7 @@ Database.prototype.update = function update(collectionName, criteria, values, cb
 				// data might be different than in db now - we are updating
 				// so we must check if value exists in db
         data.forEach(function(record) {
-//delete old one
+				//delete old one
           multi.srem(key, record[name]);
 					// if something is changed and we have some indexing before - delete new one
 					if(record[name]!=values[name]){
@@ -794,7 +795,7 @@ Database.prototype._sequencedIndices=function _sequencedIndices(collectionName){
  * @param {Function} callback
  */
 
-Database.prototype._uniqueConstraint = function _uniqueConstraint(collectionName, data, cb) {
+Database.prototype._uniqueConstraint = function _uniqueConstraint(collectionName, data, cb, alreadyIndexed) {
 
   // Grab the indices for this collection
   var indices = this.schema._indices[collectionName];
@@ -836,7 +837,7 @@ Database.prototype._uniqueConstraint = function _uniqueConstraint(collectionName
 
       // If no value is set, ignore it
       if(!hasOwnProperty(data, idx.name)) return next();
-			self.alreadyIndexed.push(idx.name);
+			alreadyIndexed.push(idx.name);
 			idx.index(data[idx.name], next);
 
     }, function(err) {

--- a/lib/database/index.js
+++ b/lib/database/index.js
@@ -51,6 +51,7 @@ var Database = module.exports = function(connection) {
 Database.prototype.configure = function configure(collectionName, schema) {
   var name = collectionName.toLowerCase();
   this.schema.registerCollection(name, schema);
+	this.alreadyIndexed=[];
 };
 
 
@@ -336,9 +337,18 @@ Database.prototype.create = function create(collectionName, data, cb) {
       primary = self.schema._primary[name];
 
   async.auto({
-
+	
     // Check Unique constraints
+    // because we dont increment primaryKey yet, it is null(if key have autoIncrementing option set to true)
+    // if key has autoIncrement option later will be set but now for checking 
+    // uniqueness it is better to remove that empty value
+    
     checkUniqueConstraints: function(next) {
+			for(var i=0,len=sequences.length;i<len;i++){
+				var column=sequences[i].name;
+				delete data[column];
+			}
+			
       self._uniqueConstraint(name, data, function(err) {
         if(err) return next(err);
         next();
@@ -504,8 +514,8 @@ Database.prototype.create = function create(collectionName, data, cb) {
 Database.prototype.update = function update(collectionName, criteria, values, cb) {
   var self = this,
       name = collectionName.toLowerCase(),
+			sequences = self.schema._sequences[name]
       primary = self.schema._primary[name];
-
 
   // Don't allow the updating of primary keys
   if(Utils.present(values[primary]) && values[primary] !== criteria.where[primary]) {
@@ -530,7 +540,7 @@ Database.prototype.update = function update(collectionName, criteria, values, cb
     // Check each Record to update meets the unique constraint rules
     checkUniqueConstraints: ['findRecords', function(next, results) {
 
-      // Get Indices
+			// Get Indices
       var indices = self.schema._indices[name];
       var indiceNames = indices.map(function(idx) { return idx.name; });
 
@@ -540,7 +550,21 @@ Database.prototype.update = function update(collectionName, criteria, values, cb
           return next(new Error('Attempting to update a unique value on multiple records'));
         }
       });
+			
+      //removing equal values because they are already in db so are not unique but that is right
+      if(results.findRecords.length){
+				if(results.findRecords.length>1)return next(new Error("There is already more than one unique value in database. Something goes terribly wrong."));
+				var already=results.findRecords[0];
+				var keys=Object.keys(values);
 
+				for(var i=0,len=keys.length;i<len;i++){
+					var key=keys[i];
+					if(hasOwnProperty(already,key))
+					if(values[key]==already[key])
+						delete values[key];
+					}
+      }
+     
       self._uniqueConstraint(name, values, function(err) {
         if(err) return next(err);
         next();
@@ -572,10 +596,10 @@ Database.prototype.update = function update(collectionName, criteria, values, cb
 
       // Cache original values
       var data = results.findRecords;
-
       // Get Indices
       var indices = self.schema._indices[name];
-
+			
+			
       // Use a MULTI wrapper to ensure the removal and creation of indexes happens atomically
       var multi = self.connection.multi();
 
@@ -584,19 +608,30 @@ Database.prototype.update = function update(collectionName, criteria, values, cb
 
         var name = idx.name;
         var key = idx.keyName;
-
         // Indexed value not updated
         if(!Utils.present(values[name])) return nextItem();
-
+				
+				var len=data.length;
+				var removed=0;
         // Remove the previously indexed values
+				// data might be different than in db now - we are updating
+				// so we must check if value exists in db
         data.forEach(function(record) {
+//delete old one
           multi.srem(key, record[name]);
+					// if something is changed and we have some indexing before - delete new one
+					if(record[name]!=values[name]){
+						if(self.alreadyIndexed.indexOf(name)>=0)
+						multi.srem(key,values[name]);
+					}
         });
-
-        // Add the new indexed value
-        multi.sadd(key, values[name]);
-
-        nextItem();
+				var autoIncrementedIndices=self._sequencedIndices(collectionName);
+        // Add the new indexed value only if it is not autoIncremented
+				if(autoIncrementedIndices.indexOf(name)<0){
+					multi.sadd(key, values[name]);
+				}
+				nextItem();
+        
       }
 
       async.each(indices, updateIndex, function(err) {
@@ -615,16 +650,18 @@ Database.prototype.update = function update(collectionName, criteria, values, cb
     // Update the record values
     updateRecords: ['updateIndexes', function(next, results) {
       var models = [];
-
+			var multi=self.connection.multi();
       function updateRecord(item, nextItem) {
         var key = self.schema.recordKey(name, primary, item[primary]);
         var updatedValues = _.extend(item, values);
 
-        self.connection.set(key, JSON.stringify(updatedValues), function(err) {
+        multi.set(key, JSON.stringify(updatedValues), function(err,result) {
           if(err) return nextItem(err);
           models.push(updatedValues);
-          nextItem();
         });
+				multi.exec(function(err){
+					nextItem();
+				});
       }
 
       async.each(results.findRecords, updateRecord, function(err) {
@@ -734,6 +771,21 @@ Database.prototype.destroy = function destroy(collectionName, criteria, cb) {
 ///////////////////////////////////////////////////////////////////////////////////////////
 
 
+Database.prototype._sequencedIndices=function _sequencedIndices(collectionName){
+	var indices = this.schema._indices[collectionName];
+	var sequences = this.schema._sequences[collectionName];
+	var autoIncrementedIndices=[];
+	for(var i=0,len=sequences.length;i<len;i++){
+		var column=sequences[i].name;
+		for(var i=0,ilen=indices.length;i<ilen;i++){
+			if(indices[i].name==column){
+				autoIncrementedIndices.push(indices[i].name);
+			}
+		}
+	}
+	return autoIncrementedIndices;
+}
+
 /**
  * Check to ensure the data is unique to the schema.
  *
@@ -746,18 +798,21 @@ Database.prototype._uniqueConstraint = function _uniqueConstraint(collectionName
 
   // Grab the indices for this collection
   var indices = this.schema._indices[collectionName];
-
+	var self=this;
   // If there are no indices for this collection, return true
   if(indices.length === 0) return cb(null, true);
 
   // Create a MULTI wrapper for this connection
   var multi = this.connection.multi();
-
-  // For each sequence, add an query to check if the index exists
+	var autoIncrementedIndices=this._sequencedIndices(collectionName);
+  
+	// For each sequence, add an query to check if the index exists
   indices.forEach(function(idx) {
-
     // If no value is set, ignore it
     if(!hasOwnProperty(data, idx.name)) return;
+		
+		// check only not autoincrementing indices
+		if(autoIncrementedIndices.indexOf(idx.name)<0)
     multi.sismember(idx.keyName, data[idx.name]);
   });
 
@@ -775,13 +830,14 @@ Database.prototype._uniqueConstraint = function _uniqueConstraint(collectionName
 
     // If unique is false return an error
     if(!unique) return cb(Errors.adapter.NotUnique);
-
+		
     // If everything was unique, create each of the indexes
     async.each(indices, function(idx, next) {
 
       // If no value is set, ignore it
       if(!hasOwnProperty(data, idx.name)) return next();
-      idx.index(data[idx.name], next);
+			self.alreadyIndexed.push(idx.name);
+			idx.index(data[idx.name], next);
 
     }, function(err) {
       if(err) return cb(err);


### PR DESCRIPTION
bug #53 and #39 - updating record - now we can save something that must be unique and already exists in db (make update) and if column is unique and autoincremented now we can save it too