### PR TITLE
Remove erroneous db config from integration tests config

### DIFF
--- a/test/integration/runner.js
+++ b/test/integration/runner.js
@@ -66,7 +66,6 @@ new TestRunner({
   // Default connection config to use.
   config: {
     host: 'localhost',
-    database: 'sails-mongo',
     port: 6379,
     schema: true,
     poolSize: 1
@@ -75,7 +74,10 @@ new TestRunner({
 
   // The set of adapter interfaces to test against.
   // (grabbed these from this adapter's package.json file above)
-  interfaces: interfaces
+  interfaces: interfaces,
+    
+  // Return non-zero code if any test failed
+  failOnError: true
 
   // Most databases implement 'semantic' and 'queryable'.
   //


### PR DESCRIPTION
Even though it looks like the integration tests are running (because they exit with code 0), the truth is slightly different, they are not being ran at all. Check the build log https://travis-ci.org/balderdashy/sails-redis/jobs/53945640#L210:
```
  1)  "before all" hook:
     Uncaught Error: ERR invalid DB index
```

This change fixes the erroneous db config and enables the adapter tests to throw non-zero if they fail.