### PR TITLE
travis: removes node.js 0.8 which breaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
-  - 0.8
   - 0.10
-  - 0.11
+  - 0.12
 services:
   - redis-server


### PR DESCRIPTION
And replaces node 0.11 for 0.12.

Should fix part of the breaking builds, PR #64 should also be merged so tests actual run!