### PR TITLE
Enable feature cross-adapter tests 

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
       "semantic",
       "queryable",
       "associations"
-    ]
+    ],
+    "features": []
   }
 }

--- a/test/integration/runner.js
+++ b/test/integration/runner.js
@@ -22,10 +22,12 @@ var Adapter = require('../../lib/adapter');
 
 // Grab targeted interfaces from this adapter's `package.json` file:
 var package = {},
-  interfaces = [];
+  interfaces = [],
+  features = [];
 try {
   package = require('../../package.json');
   interfaces = package.waterlineAdapter.interfaces;
+  features = package.waterlineAdapter.features;
 } catch (e) {
   throw new Error(
     '\n' +
@@ -75,7 +77,11 @@ new TestRunner({
 
   // The set of adapter interfaces to test against.
   // (grabbed these from this adapter's package.json file above)
-  interfaces: interfaces
+  interfaces: interfaces,
+  
+  // The set of adapter features to test against.
+  // (grabbed these from this adapter's package.json file above)
+  features: features,
 
   // Most databases implement 'semantic' and 'queryable'.
   //


### PR DESCRIPTION
To make use of the new feature tests introduced by balderdashy/waterline-adapter-tests#64.

For now features is empty as sails-redis will likely break the cross-adapter tests.