### PR TITLE
Integration tests: disable bail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 0.10
-  - 0.12
+  - "0.10"
+  - "0.12"
 services:
   - redis-server

--- a/test/integration/runner.js
+++ b/test/integration/runner.js
@@ -59,7 +59,7 @@ new TestRunner({
 
   // Mocha opts
   mocha: {
-    bail: true
+    bail: false
   },
 
   // Load the adapter module.


### PR DESCRIPTION
Disable `mocha: bail` so it's easier to see if any test has been fixed or if any additional tests has been broken. This is quite useful while evaluating new PRs.

Additionally I've added quotes to node versions in travis.yml as travis is using 0.1 instead of 0.10!

cc: @particlebanana 