### PR TITLE
Added config.url for connecting to a redis URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,24 @@ config: {
 };
 ```
 
+Alternatively the URL notation for configuration can be used for configuration:
+
+``` javascript
+config {
+  url: 'redis://h:abc123@host.com:6379'
+}
+
+// Equivalent to:
+// config: {
+//   port: 6379,
+//   host: 'host.com'
+//   password: 'abc123'
+// }
+// Other portions of the URL, including the 'username' 'h' are ignored
+```
+
+Note that if both the 'url' notation and the 'host', 'port' and / or 'password' notations are used, the non-url configuration options will take precedence.
+
 #### Low-Level Configuration (for redis driver)
 
 Configuration for the underlying Redis driver itself is located as an object under the `options`.  The following options are available:

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -3,6 +3,7 @@
  */
 
 var redis = require('redis');
+var url = require("url");
 
 /**
  * Connection.js
@@ -48,6 +49,16 @@ var Connection = module.exports = function(config, cb) {
 Connection.prototype.connect = function(cb) {
   var client,
       config = this.config;
+
+  // parse redis url for config options
+  if (config.url !== undefined) {
+    var redisUrl = url.parse(config.url);
+    config.host = config.host || redisUrl.hostname;
+    config.port = config.port || redisUrl.port;
+    if (config.options && !config.options.auth_pass && redisUrl.auth) {
+      config.options.auth_pass = redisUrl.auth.split(":")[1];
+    }
+  }
 
   client = redis.createClient(config.port, config.host, config.options);
 


### PR DESCRIPTION
Not sure if this is a comprehensive set of URL options, but it's the ones that matter for Heroku and has been tested against Heroku's URL settings.