### PR TITLE
Redis instability fix

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -73,4 +73,11 @@ Connection.prototype.connect = function(cb) {
 
     cb(null, client);
   });
+
+  client.on('error', function (err) {
+    sails && sails.log.error('RedisClient::Events[error], ' + err);
+    if (/ECONNREFUSED/g.test(err)) {
+        sails && sails.log.error('Waiting for redis client to come back online. Connections:', client.connections);
+    }
+  });
 };


### PR DESCRIPTION
This PR fixes the issue with adapter that causes sails to crash at the instant redis connection is broken.

The issue existed within socket communication of SailsJS a while back in the issue https://github.com/balderdashy/sails/issues/2276

Almost quoting the original issue:

> Steps to reproduce current bug:
> 1) Make sure you have configured Redis as connection to at least one model
> 2) sails lift (while redis is running)
> 3) go to a page on your app, or any route that works - it works
> 4) now shutdown redis
> 5) sails has crashed


Fix is simple:
Attaching 'error' event to redis client prevents server crash when redis connection fails.

Without this fix, sails-redis is unusable in production environment. Please merge and release.