### PR TITLE
Add hiredis as optional dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,9 @@
     "waterline-criteria": "~0.11.1",
     "waterline-cursor": "~0.0.5"
   },
+  "optionalDependencies": {
+    "hiredis": "~0.4.1"
+  },
   "waterlineAdapter": {
     "waterlineVersion": "~0.10.0",
     "interfaces": [


### PR DESCRIPTION
This will increase performance while not breaking on some people's machines. If an optional dependency fails to build, then it is ignored. `hiredis` is much faster than the JS parser used when it is not included.