### PR TITLE
trigger the connect callback with an error if redis errors and exits …

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -66,6 +66,9 @@ Connection.prototype.connect = function(cb) {
   }
 
   client = redis.createClient(config.port, config.host, config.options);
+  
+  var readyFired = false;
+  var lastError;
 
   if(config.password != null) {
     client.auth(config.password);
@@ -76,14 +79,26 @@ Connection.prototype.connect = function(cb) {
       client.select(config.database);
     }
 
+    readyFired = true;
+    
     cb(null, client);
   });
 
+  client.on('end', function() {
+    // check that it exited before ready (i.e. before it connected successfully),
+    // and that an error was received
+    if (!readyFired && lastError) {
+      cb(lastError);
+    }
+  });
+  
   client.on('error', function (err) {
-      log('RedisClient::Events[error], ',  err);
+    lastError = err;
+    
+    log('RedisClient::Events[error], ',  err);
 
-      if (/ECONNREFUSED/g.test(err)) {
-          log('Waiting for redis client to come back online. Connections:', client.connections);
-      }
+    if (/ECONNREFUSED/g.test(err)) {
+        log('Waiting for redis client to come back online. Connections:', client.connections);
+    }
   });
 };


### PR DESCRIPTION
…before it has connected successfully

This requires that the adapter be configured with a `max_attemps` parameter for the `redis` module, as such:

```
var config = {
  adapters: { redis: require('sails-redis') },
  connections: {
    default: {
      adapter: 'redis',
      options: {
        max_attempts: 1
      }
    }
  }
}
```

https://github.com/balderdashy/sails-redis/issues/87