### PR TITLE
Possibility to have custom keys' prefix

### DIFF
--- a/lib/database/index.js
+++ b/lib/database/index.js
@@ -23,11 +23,11 @@ var Database = module.exports = function(connection) {
   connection = connection || { connection: {} };
 
   this.connection = connection.connection;
-
+  this.key_prefix=connection.config.key_prefix||"waterline:";
   this.definedCollections = {};
 
   // Hold Schema for the database
-  this.schema = new Schema(connection);
+  this.schema = new Schema(connection,{key_prefix:this.key_prefix});
 
   return this;
 };

--- a/lib/database/indice.js
+++ b/lib/database/indice.js
@@ -12,7 +12,7 @@ var Errors = require('waterline-errors'),
  * values that can be checked against to determine if a value is unique or not.
  */
 
-var Indice = module.exports = function(collectionName, name, client) {
+var Indice = module.exports = function(collectionName, name, client,options) {
 
   // Escape the collection name
   var collection = collectionName.toLowerCase();
@@ -22,9 +22,9 @@ var Indice = module.exports = function(collectionName, name, client) {
 
   // Set the name of the sequence
   this.name = Utils.sanitize(name);
-  var prefix = options.key_prefix||"waterline:";
+  var key_prefix = options.key_prefix||"waterline:";
   // Build a NoSQL Key name for this sequence
-  this.keyName = prefix + collection + ':_indicies:' + this.name;
+  this.keyName = key_prefix + collection + ':_indicies:' + this.name;
 
   return this;
 };

--- a/lib/database/indice.js
+++ b/lib/database/indice.js
@@ -22,9 +22,9 @@ var Indice = module.exports = function(collectionName, name, client) {
 
   // Set the name of the sequence
   this.name = Utils.sanitize(name);
-
+  var prefix = options.key_prefix||"waterline:";
   // Build a NoSQL Key name for this sequence
-  this.keyName = 'waterline:' + collectionName.toLowerCase() + ':_indicies:' + this.name;
+  this.keyName = prefix + collection + ':_indicies:' + this.name;
 
   return this;
 };

--- a/lib/database/schema.js
+++ b/lib/database/schema.js
@@ -74,7 +74,7 @@ Schema.prototype.registerCollection = function(collectionName, schema) {
 
     // Create a sequence for the attribute
     if(Utils.object.hasOwnProperty(schema[attr], 'autoIncrement')) {
-      var sequence = new Sequence(name, attr, this._connection);
+      var sequence = new Sequence(name, attr, this._connection,{key_prefix:this.key_prefix});
       this._sequences[name].push(sequence);
     }
   }

--- a/lib/database/schema.js
+++ b/lib/database/schema.js
@@ -32,7 +32,7 @@ var Schema = module.exports = function(connection,options) {
 
   // Save the connection
   this._connection = connection;
-  this._prefix = options.key_prefix||"waterline:";
+  this.key_prefix = options.key_prefix||"waterline:";
   return this;
 
 };
@@ -68,7 +68,7 @@ Schema.prototype.registerCollection = function(collectionName, schema) {
 
     // Create an index for the attribute
     if(hasOwnProperty(schema[attr], 'unique')) {
-      var indice = new Indice(name, attr, this._connection);
+      var indice = new Indice(name, attr, this._connection,{key_prefix:this.key_prefix});
       this._indices[name].push(indice);
     }
 
@@ -129,7 +129,7 @@ Schema.prototype.retrieve = function(collectionName) {
 
 Schema.prototype.indexKey = function(collectionName, index) {
   var name = collectionName.toLowerCase();
-  return this._prefix + name + ':' + index;
+  return this.key_prefix + name + ':' + index;
 };
 
 /**
@@ -144,7 +144,7 @@ Schema.prototype.indexKey = function(collectionName, index) {
 Schema.prototype.recordKey = function(collectionName, index, key) {
   var name = collectionName.toLowerCase();
   var keyName = Utils.replaceSpaces( key );
-  return this._prefix + name + ':' + index + ':' + keyName;
+  return this.key_prefix + name + ':' + index + ':' + keyName;
 };
 
 /**

--- a/lib/database/schema.js
+++ b/lib/database/schema.js
@@ -16,7 +16,7 @@ var _ = require('lodash'),
  * Keeps track of the "schema".
  */
 
-var Schema = module.exports = function(connection) {
+var Schema = module.exports = function(connection,options) {
 
   // Hold the schema for each collection
   this._schema = {};
@@ -32,7 +32,7 @@ var Schema = module.exports = function(connection) {
 
   // Save the connection
   this._connection = connection;
-
+  this._prefix = options.key_prefix||"waterline:";
   return this;
 
 };
@@ -129,7 +129,7 @@ Schema.prototype.retrieve = function(collectionName) {
 
 Schema.prototype.indexKey = function(collectionName, index) {
   var name = collectionName.toLowerCase();
-  return 'waterline:' + name + ':' + index;
+  return this._prefix + name + ':' + index;
 };
 
 /**
@@ -144,7 +144,7 @@ Schema.prototype.indexKey = function(collectionName, index) {
 Schema.prototype.recordKey = function(collectionName, index, key) {
   var name = collectionName.toLowerCase();
   var keyName = Utils.replaceSpaces( key );
-  return 'waterline:' + name + ':' + index + ':' + keyName;
+  return this._prefix + name + ':' + index + ':' + keyName;
 };
 
 /**

--- a/lib/database/sequence.js
+++ b/lib/database/sequence.js
@@ -11,7 +11,7 @@ var Utils = require('../utils');
  * tracking the last value available and can be incremented only.
  */
 
-var Sequence = module.exports = function(collectionName, name, client) {
+var Sequence = module.exports = function(collectionName, name, client, options) {
 
   // Escape the collection name
   var collection = collectionName.toLowerCase();
@@ -21,9 +21,9 @@ var Sequence = module.exports = function(collectionName, name, client) {
 
   // Set the name of the sequence
   this.name = Utils.sanitize(name);
-
+  this.key_prefix=options.key_prefix||"waterline:";
   // Build a NoSQL Key name for this sequence
-  this.keyName = 'waterline:' + collectionName.toLowerCase() + ':_sequences:' + this.name;
+  this.keyName = this.key_prefix + collectionName.toLowerCase() + ':_sequences:' + this.name;
 
   return this;
 };


### PR DESCRIPTION
If two apps uses the same redis db there could be a key confict 
Eg:

```
 app1 creates a new user with id:7 (key: waterline:user:id:7)
 app2 lists all users (keys: "waterline:user:*")
 app2 will get information about user:if:7 of app 1
```
Giving the possibility to set a custom prefix would avoid such conflict by, in example, declaring the app name in the fileld 'key_prefix'
Eg:
```
...
connections:{
        redis:{
            adapter:'redis',
            host:"localhost",
            key_prefix:"com.example.myappid"
            }
    },
...
```

