### PR TITLE
Fix Issue with updating unique values

### DIFF
--- a/lib/database/index.js
+++ b/lib/database/index.js
@@ -550,7 +550,7 @@ Database.prototype.update = function update(collectionName, criteria, values, cb
           return next(new Error('Attempting to update a unique value on multiple records'));
         }
       });
-
+      
       self._uniqueConstraint(name, values, function(err) {
         if(err) return next(err);
         next();
@@ -579,7 +579,7 @@ Database.prototype.update = function update(collectionName, criteria, values, cb
 
     // Update any indexed values that have been created
     updateIndexes: ['checkUniqueConstraints', 'checkPrimaryKeyValid', function(next, results) {
-
+      
       // Cache original values
       var data = results.findRecords;
 
@@ -602,9 +602,6 @@ Database.prototype.update = function update(collectionName, criteria, values, cb
         data.forEach(function(record) {
           multi.srem(key, record[name]);
         });
-
-        // Add the new indexed value
-        multi.sadd(key, values[name]);
 
         nextItem();
       }

--- a/test/unit/adapter.update.js
+++ b/test/unit/adapter.update.js
@@ -86,5 +86,13 @@ describe('adapter `.update()`', function() {
         done();
       });
     });
+    
+    it('should update unique fields to another unique value', function(done) {
+      Adapter.update('update', 'update', { where: { name: 'The Dude' }}, { name: 'Lebowski' }, function(err, model) {
+        if(err) throw err;
+        assert(model[0].name === 'Lebowski');
+        done();
+      });
+    });
   });
 });


### PR DESCRIPTION
It turns out the problem was that the index was added to the unique set at two different points. This doesn't seem to break anything, all old tests still pass. I added a test that fails without the change, and passes with the change.